### PR TITLE
Creating basic implementations of Sources and ProjectWebRootProvider SPI...

### DIFF
--- a/netbeans-gradle-javaee-plugin/pom.xml
+++ b/netbeans-gradle-javaee-plugin/pom.xml
@@ -12,7 +12,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <netbeans.version>RELEASE72</netbeans.version>
+        <netbeans.version>RELEASE74</netbeans.version>
     </properties>
 
     <repositories>
@@ -117,6 +117,12 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>org.netbeans.modules</groupId>
+            <artifactId>org-netbeans-modules-web-common</artifactId>
+            <version>${netbeans.version}</version>
+            <type>jar</type>
+        </dependency>
     </dependencies>
 
     <build>
@@ -138,8 +144,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.1</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>1.7</source>
+                    <target>1.7</target>
                 </configuration>
             </plugin>
 

--- a/netbeans-gradle-javaee-plugin/src/main/java/org/netbeans/gradle/javaee/web/WebModuleExtension.java
+++ b/netbeans-gradle-javaee-plugin/src/main/java/org/netbeans/gradle/javaee/web/WebModuleExtension.java
@@ -16,6 +16,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import org.netbeans.gradle.javaee.web.sources.GradleSources;
+import org.netbeans.gradle.javaee.web.sources.GradleWebRootProvider;
 
 /**
  *
@@ -28,7 +30,11 @@ public class WebModuleExtension implements GradleProjectExtension {
 
     public WebModuleExtension(Project project) {
         this.project = project;
-        extensionLookup = Lookups.singleton(new GradleWebModuleProvider(project));
+        extensionLookup = Lookups.fixed(
+            new GradleWebModuleProvider(project),
+            new GradleSources(project),
+            new GradleWebRootProvider(project)
+        );
     }
 
     @Override

--- a/netbeans-gradle-javaee-plugin/src/main/java/org/netbeans/gradle/javaee/web/sources/GradleSources.java
+++ b/netbeans-gradle-javaee-plugin/src/main/java/org/netbeans/gradle/javaee/web/sources/GradleSources.java
@@ -1,0 +1,68 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+
+package org.netbeans.gradle.javaee.web.sources;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import javax.swing.event.ChangeListener;
+import org.netbeans.api.project.Project;
+import org.netbeans.api.project.SourceGroup;
+import org.netbeans.api.project.Sources;
+import static org.netbeans.gradle.javaee.web.sources.Bundle.LABEL_WebPages;
+import org.netbeans.gradle.javaee.web.utils.Constants;
+import org.netbeans.modules.web.common.spi.ProjectWebRootProvider;
+import org.netbeans.spi.project.support.GenericSources;
+import org.openide.filesystems.FileObject;
+import org.openide.util.NbBundle;
+
+/**
+ * Implementation of {@link Sources} interface for Java EE Gradle projects.
+ *
+ * <p>
+ * This class is <i>immutable</i> and thus <i>thread safe</i>.
+ *
+ * @author Martin Janicek <mjanicek@netbeans.org>
+ */
+public final class GradleSources implements Sources {
+
+    private final Project project;
+
+
+    public GradleSources(Project project) {
+        this.project = project;
+    }
+
+    @Override
+    public SourceGroup[] getSourceGroups(String string) {
+        List<SourceGroup> sourceGroups = new ArrayList<>();
+
+        ProjectWebRootProvider webRootProvider = project.getLookup().lookup(ProjectWebRootProvider.class);
+        if (webRootProvider != null) {
+            for (FileObject webRoot : webRootProvider.getWebRoots()) {
+                sourceGroups.add(GenericSources.group(project, webRoot, Constants.WEB_ROOT, getDisplayName(), null, null));
+            }
+        }
+
+        return sourceGroups.toArray(new SourceGroup[sourceGroups.size()]);
+    }
+
+    @NbBundle.Messages("LABEL_WebPages=Web Pages")
+    private String getDisplayName() {
+        return LABEL_WebPages();
+    }
+
+    @Override
+    public void addChangeListener(ChangeListener changeListener) {
+        // I guess there is no need to listen on Source changes at the moment
+    }
+
+    @Override
+    public void removeChangeListener(ChangeListener changeListener) {
+        // I guess there is no need to listen on Source changes at the moment
+    }
+}

--- a/netbeans-gradle-javaee-plugin/src/main/java/org/netbeans/gradle/javaee/web/sources/GradleWebRootProvider.java
+++ b/netbeans-gradle-javaee-plugin/src/main/java/org/netbeans/gradle/javaee/web/sources/GradleWebRootProvider.java
@@ -1,0 +1,46 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+
+package org.netbeans.gradle.javaee.web.sources;
+
+import java.util.Collection;
+import java.util.Collections;
+import org.netbeans.api.project.Project;
+import org.netbeans.modules.web.common.spi.ProjectWebRootProvider;
+import org.openide.filesystems.FileObject;
+
+/**
+ * This class is <i>immutable</i> and thus <i>thread safe</i>.
+ *
+ * @author Martin Janicek <mjanicek@netbeans.org>
+ */
+public final class GradleWebRootProvider implements ProjectWebRootProvider {
+
+    private final FileObject projectDir;
+
+
+    public GradleWebRootProvider(Project project) {
+        this.projectDir = project.getProjectDirectory();
+    }
+
+    @Override
+    public FileObject getWebRoot(FileObject fo) {
+        FileObject webAppFO = projectDir.getFileObject("src/main/webapp");
+        if (webAppFO != null) {
+            return webAppFO;
+        }
+        return null;
+    }
+
+    @Override
+    public Collection<FileObject> getWebRoots() {
+        FileObject webRoot = getWebRoot(projectDir);
+        if (webRoot != null) {
+            return Collections.singletonList(getWebRoot(projectDir));
+        }
+        return Collections.emptyList();
+    }
+}

--- a/netbeans-gradle-javaee-plugin/src/main/java/org/netbeans/gradle/javaee/web/utils/Constants.java
+++ b/netbeans-gradle-javaee-plugin/src/main/java/org/netbeans/gradle/javaee/web/utils/Constants.java
@@ -1,0 +1,23 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+
+package org.netbeans.gradle.javaee.web.utils;
+
+/**
+ * General constants which does not belong logically to any particular class.
+ * 
+ * <p>
+ * This class is <i>immutable</i> and thus <i>thread safe</i>.
+ *
+ * @author Martin Janicek <mjanicek@netbeans.org>
+ */
+public final class Constants {
+
+    private Constants() {
+    }
+
+    public static final String WEB_ROOT = "web_root"; // NOI18N
+}


### PR DESCRIPTION
..., adding implementation dependency on web.common module, changing pom dependencies to be bounded to latest RELEASE74 version, changing the module to use Java 7 as it's standard and recommended JDK version since NetBeans 7.4
