### PR TITLE
review WebModuleExtensionDef.parseModel

### DIFF
--- a/netbeans-gradle-javaee-plugin/src/main/java/org/netbeans/gradle/javaee/web/WebModuleExtensionDef.java
+++ b/netbeans-gradle-javaee-plugin/src/main/java/org/netbeans/gradle/javaee/web/WebModuleExtensionDef.java
@@ -67,6 +67,7 @@ public class WebModuleExtensionDef implements GradleProjectExtensionDef<NbWebMod
     public ParsedModel<NbWebModel> parseModel(ModelLoadResult retrievedModels) {
         LOGGER.entering(this.getClass().getName(), "parseModel", retrievedModels);
         ParsedModel<NbWebModel> returnValue = null;
+        // XXX: My log files suggest that the lookup method is returning null
         NbWebModel webModel = retrievedModels.getMainProjectModels().lookup(NbWebModel.class);
         if (webModel != null) {
             returnValue = new ParsedModel(webModel);


### PR DESCRIPTION
From my logs:
    
    var/log/messages.log:FINER [org.netbeans.gradle.javaee.web.WebModuleExtensionDef]: RETURN null
    var/log/messages.log:WARNING [org.netbeans.gradle.project.NbGradleExtensionRef]: GradleProjectExtensionDef.parseModel returned null for extension org.netbeans.gradle.javaee.web.WebModuleExtensionDef