### PR TITLE
NetBeans 9 upgrade

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,6 @@ allprojects {
     version = '1.0.3'
 
     ext {
-        nbGradleVersion = '1.4.0'
+        nbGradleVersion = '2.0.0.1'
     }
 }

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -12,7 +12,7 @@ dependencies {
     compile localGroovy()
     compile 'org.gradle:gradle-tooling-api:1.11'
     compile 'org.codehaus.mojo:nbm-maven-harness:7.4'
-    compile 'cz.kubacki.gradle.plugins:gradle-nbm-plugin:1.15.0'
+    compile 'cz.kubacki.gradle.plugins:gradle-nbm-plugin:1.17.0'
     compile 'org.apache.maven.shared:maven-dependency-analyzer:1.6'
     runtime 'org.slf4j:slf4j-simple:1.7.5'
 }

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -1,6 +1,6 @@
 apply plugin: 'groovy'
 
-def javaVersion = 1.7
+def javaVersion = 1.8
 sourceCompatibility = javaVersion
 targetCompatibility = javaVersion
 

--- a/buildSrc/src/main/groovy/org/netbeans/gradle/build/NbmDependencyVerifierPlugin.java
+++ b/buildSrc/src/main/groovy/org/netbeans/gradle/build/NbmDependencyVerifierPlugin.java
@@ -43,7 +43,8 @@ import org.gradle.jvm.tasks.Jar;
 
 public final class NbmDependencyVerifierPlugin implements Plugin<Project> {
     private static final List<VersionlessArtifactId> UNCHECKED = Arrays.asList(
-            new VersionlessArtifactId("com.github.kelemen", "netbeans-gradle-default-models"));
+            new VersionlessArtifactId("com.github.kelemen", "netbeans-gradle-default-models"),
+            new VersionlessArtifactId("org.jtrim2", null));
 
     @Override
     public void apply(final Project project) {
@@ -145,9 +146,19 @@ public final class NbmDependencyVerifierPlugin implements Plugin<Project> {
         }
     }
 
+    private static boolean matches(String searched, String pattern) {
+        if (pattern == null) {
+            return true;
+        }
+        return Objects.equals(searched, pattern);
+    }
+
     private static boolean contains(ModuleComponentIdentifier dependency, Collection<VersionlessArtifactId> collection) {
         VersionlessArtifactId searched = new VersionlessArtifactId(dependency.getGroup(), dependency.getModule());
-        return collection.contains(searched);
+        return collection.stream().filter(unchecked -> {
+            return matches(searched.group, unchecked.group)
+                    && matches(searched.name, unchecked.name);
+        }).findAny().isPresent();
     }
 
     private static Configuration getUncheckedDependencies(Project project, Configuration providedCompile) {
@@ -255,25 +266,6 @@ public final class NbmDependencyVerifierPlugin implements Plugin<Project> {
         public VersionlessArtifactId(String group, String name) {
             this.group = group;
             this.name = name;
-        }
-
-        @Override
-        public int hashCode() {
-            int hash = 5;
-            hash = 89 * hash + Objects.hashCode(group);
-            hash = 89 * hash + Objects.hashCode(name);
-            return hash;
-        }
-
-        @Override
-        public boolean equals(Object obj) {
-            if (this == obj) return true;
-            if (obj == null) return false;
-            if (getClass() != obj.getClass()) return false;
-
-            final VersionlessArtifactId other = (VersionlessArtifactId) obj;
-            return Objects.equals(this.group, other.group)
-                    && Objects.equals(this.name, other.name);
         }
     }
 }

--- a/netbeans-gradle-javaee-models/src/modelBuilders/groovy/org/netbeans/gradle/javaee/models/NbJpaModelBuilder.java
+++ b/netbeans-gradle-javaee-models/src/modelBuilders/groovy/org/netbeans/gradle/javaee/models/NbJpaModelBuilder.java
@@ -7,7 +7,7 @@ import org.gradle.api.Project;
 import org.gradle.api.file.SourceDirectorySet;
 import org.gradle.api.plugins.JavaPluginConvention;
 import org.gradle.api.tasks.SourceSet;
-import org.jtrim.utils.ExceptionHelper;
+import org.jtrim2.utils.ExceptionHelper;
 import org.netbeans.gradle.model.api.ProjectInfoBuilder2;
 
 /**

--- a/netbeans-gradle-javaee-plugin/build.gradle
+++ b/netbeans-gradle-javaee-plugin/build.gradle
@@ -44,8 +44,8 @@ nbm {
     }
 }
 
-sourceCompatibility = 1.7
-targetCompatibility = 1.7
+sourceCompatibility = 1.8
+targetCompatibility = 1.8
 
 configurations {
     pluginInstall

--- a/netbeans-gradle-javaee-plugin/build.gradle
+++ b/netbeans-gradle-javaee-plugin/build.gradle
@@ -4,14 +4,16 @@ apply plugin: 'java'
 apply plugin: 'cz.kubacki.nbm'
 apply plugin: 'nbm-dependency-verifier'
 
-String netbeansVersion = 'RELEASE81'
+String netbeansVersion = 'dev-SNAPSHOT'
 
 repositories {
     mavenCentral()
-    maven { url 'http://bits.netbeans.org/nexus/content/groups/netbeans' }
-    maven { url 'http://bits.netbeans.org/maven2/' }
+    String nbRepo = netbeansVersion.endsWith('-SNAPSHOT')
+            ? 'http://bits.netbeans.org/netbeans/trunk/new-maven-snapshot'
+            : 'http://bits.netbeans.org/nexus/content/groups/netbeans'
+    maven { url nbRepo }
+    jcenter()
     maven { url 'http://repo.gradle.org/gradle/libs-releases-local' }
-    maven { url 'http://dl.bintray.com/kelemen/maven' }
 }
 
 def tryGetProperty = { String name, String defaultValue ->

--- a/netbeans-gradle-javaee-plugin/src/main/java/org/netbeans/gradle/javaee/web/nodes/WebModuleExtensionNodes.java
+++ b/netbeans-gradle-javaee-plugin/src/main/java/org/netbeans/gradle/javaee/web/nodes/WebModuleExtensionNodes.java
@@ -7,7 +7,6 @@
 package org.netbeans.gradle.javaee.web.nodes;
 
 import org.netbeans.gradle.javaee.web.WebModuleExtension;
-import org.netbeans.gradle.project.api.event.NbListenerRef;
 import org.netbeans.gradle.project.api.nodes.GradleProjectExtensionNodes;
 import org.netbeans.gradle.project.api.nodes.ManualRefreshedNodes;
 import org.netbeans.gradle.project.api.nodes.SingleNodeFactory;
@@ -23,9 +22,10 @@ import java.util.logging.Logger;
 
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
+import org.jtrim2.concurrent.Tasks;
+import org.jtrim2.event.ListenerRef;
 import org.netbeans.gradle.javaee.web.ModelReloadListener;
 import org.netbeans.gradle.javaee.models.NbWebModel;
-import org.netbeans.gradle.project.api.event.NbListenerRefs;
 import org.openide.util.ChangeSupport;
 
 /**
@@ -65,7 +65,7 @@ public class WebModuleExtensionNodes implements GradleProjectExtensionNodes, Mod
     }
 
     @Override
-    public NbListenerRef addNodeChangeListener(final Runnable listener) {
+    public ListenerRef addNodeChangeListener(final Runnable listener) {
         final ChangeListener changeListener = new ChangeListener() {
             @Override
             public void stateChanged(ChangeEvent e) {
@@ -74,12 +74,9 @@ public class WebModuleExtensionNodes implements GradleProjectExtensionNodes, Mod
         };
 
         nodeChanges.addChangeListener(changeListener);
-        return NbListenerRefs.fromRunnable(new Runnable() {
-            @Override
-            public void run() {
-                nodeChanges.removeChangeListener(changeListener);
-            }
-        });
+        return Tasks.runOnceTask(() -> {
+            nodeChanges.removeChangeListener(changeListener);
+        })::run;
     }
 
     @Override


### PR DESCRIPTION
**Please, merge this into a new branch instead of master**.

I have added incompatible changes to the core NB Gradle plugin for NetBeans 9. This PR contains changes to fix the compatibility issues. Once NetBeans 9 is out, please build this instead of the current master. If you want to have releases for older versions of NB, you have to keep using the current master.

Also, since NetBeans 9 was not yet released, I have adjusted to dependencies to depend on "dev-SNAPSHOT" for now (this must be changed before release).